### PR TITLE
Add date as possible source field for date attribute

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -84,7 +84,7 @@ function cleanAccents(str) {
 
 function jsonOfEntry(entry) {
   const authors = _.map(entry.getAuthors().authors$, (auth, _) => auth.firstNames + " " + auth.lastNames).map(cleanAccents).map(x => x.trim());
-  const date = (entry.getFieldAsString('issue_date') ? entry.getFieldAsString('issue_date') : entry.getFieldAsString('year')).toString();
+  const date = (entry.getFieldAsString('issue_date') ? entry.getFieldAsString('issue_date') : entry.getFieldAsString('year') ? entry.getFieldAsString('year') : entry.getFieldAsString('date')).toString();
   const youtubeId = entry.getFieldAsString('youtubeId') ? entry.getFieldAsString('youtubeId') : getYoutubeId(entry.getFieldAsString('youtube'));
   const entry_type = entry.type;
   const ret = {};


### PR DESCRIPTION
Can we add `date` as a possible field to populate the date attribute? I have a particular use-case where we use *date* instead of *issue_date* or *year*. And I guess that probably more people want to be able to use *date* as a field name 😊